### PR TITLE
Add view toggle on re-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.0.4 - 2017-11-19
+- Added view toggle on button re-click
+
 # v0.0.3 - 2017-10-23
 - Fixed stupid lowercase function
 

--- a/extension.js
+++ b/extension.js
@@ -11,6 +11,7 @@ var views = vscode.workspace.getConfiguration( 'activitusbar' )
 var icons = { explorer: "file-text", search: "search", scm: "repo-forked", debug: "bug", extensions: "package" };
 var buttons = [];
 
+var open = 'hide';
 var startingPriority = 99999;
 
 String.prototype.capitalize = function()
@@ -39,8 +40,15 @@ function deselect()
 function selectView( view )
 {
     deselect();
+    if(open == view || view == 'hide')
+    {
+        vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility")
+    }
+    else{
     vscode.commands.executeCommand( 'workbench.view.' + view );
     buttons[ view ].color = activeColour();
+}
+        open = view;
 }
 
 function selectExplorerView() { selectView( 'explorer' ); }

--- a/package.json
+++ b/package.json
@@ -1,78 +1,83 @@
 {
-    "name": "activitusbar",
-    "displayName": "Activitus Bar",
-    "description": "Save some real estate by recreating the activity bar buttons on the status bar",
-    "version": "0.0.3",
-    "icon": "icon.png",
-    "publisher": "Gruntfuggly",
-    "engines": {
-        "vscode": "^1.5.0"
-    },
-    "repository": "https://github.com/Gruntfuggly/activitusbar",
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./extension",
-    "contributes": {
-        "keybindings": [
-            {
-                "command": "activitusbar.selectExplorerView",
-                "key": "ctrl+shift+E",
-                "mac": "shift+cmd+E"
-            },
-            {
-                "command": "activitusbar.selectSearchView",
-                "key": "ctrl+shift+F",
-                "mac": "shift+cmd+F"
-            },
-            {
-                "command": "activitusbar.selectScmView",
-                "key": "ctrl+shift+G",
-                "mac": "ctrl+shift+G"
-            },
-            {
-                "command": "activitusbar.selectDebugView",
-                "key": "ctrl+shift+D",
-                "mac": "shift+cmd+D"
-            },
-            {
-                "command": "activitusbar.selectExtensionsView",
-                "key": "ctrl+shift+X",
-                "mac": "shift+cmd+X"
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "Activitus Bar configuration",
-            "properties": {
-                "activitusbar.views": {
-                    "type": "string",
-                    "description": "Views to include on the status bar (separated by commas, requires reload)",
-                    "default": "explorer,search,scm,debug,extensions"
-                },
-                "activitusbar.inactiveColour": {
-                    "type": "string",
-                    "description": "Colour of inactive icons",
-                    "default": "#bbb"
-                },
-                "activitusbar.activeColour": {
-                    "type": "string",
-                    "description": "Colour of the active icon",
-                    "default": "#fff"
-                }
-            }
-        }
-    },
-    "scripts": {},
-    "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "eslint": "^3.6.0",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
-    }
+	"name": "activitusbar",
+	"displayName": "Activitus Bar",
+	"description": "Save some real estate by recreating the activity bar buttons on the status bar",
+	"version": "0.0.4",
+	"icon": "icon.png",
+	"publisher": "Gruntfuggly",
+	"engines": {
+		"vscode": "^1.5.0"
+	},
+	"repository": "https://github.com/Gruntfuggly/activitusbar",
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"*"
+	],
+	"main": "./extension",
+	"contributes": {
+		"keybindings": [
+			{
+				"command": "activitusbar.selectExplorerView",
+				"key": "ctrl+shift+E",
+				"mac": "shift+cmd+E"
+			},
+			{
+				"command": "activitusbar.selectSearchView",
+				"key": "ctrl+shift+F",
+				"mac": "shift+cmd+F"
+			},
+			{
+				"command": "activitusbar.selectScmView",
+				"key": "ctrl+shift+G",
+				"mac": "ctrl+shift+G"
+			},
+			{
+				"command": "activitusbar.selectDebugView",
+				"key": "ctrl+shift+D",
+				"mac": "shift+cmd+D"
+			},
+			{
+				"command": "activitusbar.selectExtensionsView",
+				"key": "ctrl+shift+X",
+				"mac": "shift+cmd+X"
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "Activitus Bar configuration",
+			"properties": {
+				"activitusbar.views": {
+					"type": "string",
+					"description": "Views to include on the status bar (separated by commas, requires reload)",
+					"default": "explorer,search,scm,debug,extensions"
+				},
+				"activitusbar.inactiveColour": {
+					"type": "string",
+					"description": "Colour of inactive icons",
+					"default": "#bbb"
+				},
+				"activitusbar.activeColour": {
+					"type": "string",
+					"description": "Colour of the active icon",
+					"default": "#fff"
+				}
+			}
+		}
+	},
+	"scripts": {},
+	"devDependencies": {
+		"typescript": "^2.0.3",
+		"vscode": "^1.0.0",
+		"mocha": "^2.3.3",
+		"eslint": "^3.6.0",
+		"@types/node": "^6.0.40",
+		"@types/mocha": "^2.2.32"
+	},
+	"__metadata": {
+		"id": "47137038-6832-49c2-a31c-9ad3d95187fc",
+		"publisherDisplayName": "Gruntfuggly",
+		"publisherId": "d4906d2e-f2ee-492d-9c7c-02b6160599ec"
+	}
 }


### PR DESCRIPTION
The extension worked fine, but there was no way to hide an opened view.
This merge adds the option to hide an opened view in the natural way of re-clicking it.