### PR TITLE
Add config to include custom activity bar buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,17 @@
 					"description": "Views to include on the status bar (separated by commas, requires reload)",
 					"default": "explorer,search,scm,debug,extensions"
 				},
+				"activitusbar.viewsIcons": {
+					"type": "object",
+					"description": "Icons for views on the status bar",
+					"default": {
+						"explorer": "file-text",
+						"search": "search",
+						"scm": "repo-forked",
+						"debug": "bug",
+						"extensions": "package"
+					}
+				},
 				"activitusbar.inactiveColour": {
 					"type": "string",
 					"description": "Colour of inactive icons",


### PR DESCRIPTION
Add new configurations to include custom activity bar buttons.

Use like this: (In User Settings)

```json
"activitusbar.views": "explorer,search,scm,debug,extensions,extension.XXX",
"activitusbar.viewsIcons": {
    "explorer": "file-text",
    "search": "search",
    "scm": "repo-forked",
    "debug": "bug",
    "extensions": "package",
    "extension.XXX": "list-unordered"
}
```

extension.XXX is the id of activitybar of the extensions, because view command of the custom activity bar is in form like "workbench.view.extension.XXX"