### PR TITLE
Remove default colours, set inactiveColour to use theme's statusBar.foreground by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The buttons are configurable, using `activitusbar.views`. This is a object conta
 
 This extension also rebinds the view selection keys. If you have modified the default key bindings, this may be an issue.
 
-The colour of the active and inactive buttons can also be specified using `activitusbar.activeColour` and `activitusbar.inactiveColour`. By default these are white (`#fff`) and grey (`#bbb`).
+The colour of the active and inactive buttons can also be specified using `activitusbar.activeColour` and `activitusbar.inactiveColour`.
 
 If required, the position of the icons can be adjusted by changing the value of `activitusbar.priority` and `activitusbar.alignment`. The defaults are `99999` and `Left` which should place them at the far left or the status bar. Depending on what other extensions are installed, you may need to experiment to find a value which suits. For example, to move everything to the far right, try `Right` and `-99999`.
 

--- a/extension.js
+++ b/extension.js
@@ -17,12 +17,12 @@ function activate( context )
 
     function inactiveColour()
     {
-        return vscode.workspace.getConfiguration( 'activitusbar' ).get( 'inactiveColour', '#bbb' );
+        return vscode.workspace.getConfiguration('activitusbar').get('inactiveColour') || new vscode.ThemeColor('statusBar.foreground');
     }
 
     function activeColour()
     {
-        return vscode.workspace.getConfiguration( 'activitusbar' ).get( 'activeColour', '#fff' );
+        return vscode.workspace.getConfiguration('activitusbar').get('activeColour');
     }
 
     function build()

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     ],
     "main": "./extension",
     "contributes": {
-        "keybindings": [
-            {
+        "keybindings": [{
                 "command": "activitusbar.showExplorerView",
                 "key": "ctrl+shift+E",
                 "mac": "shift+cmd+E"
@@ -73,13 +72,11 @@
                 },
                 "activitusbar.inactiveColour": {
                     "type": "string",
-                    "description": "Colour of inactive icons",
-                    "default": "#bbb"
+                    "description": "Colour of inactive icons"
                 },
                 "activitusbar.activeColour": {
                     "type": "string",
-                    "description": "Colour of the active icon",
-                    "default": "#fff"
+                    "description": "Colour of the active icon"
                 },
                 "activitusbar.priority": {
                     "type": "integer",


### PR DESCRIPTION
I noticed the current default colours don't play too well when using a plugin like [vscode-peacock](https://github.com/johnpapa/vscode-peacock), where the statusBar colour can be changed per project.

Instead of updating the activitusbar settings for every project, I've changed the `inactiveColour` to fallback to `ThemeColor('statusBar.foreground')` if not set.

Status bar items don't have an "active" state by default, so I've removed the default applied by the plugin. Both can still be overridden and it shouldn't affect anyone's existing settings.