### PR TITLE
Add "extensionKind" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "*"
     ],
     "main": "./extension",
+    "extensionKind" ["ui", "workspace"],
     "contributes": {
         "keybindings": [
             {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "*"
     ],
     "main": "./extension",
-    "extensionKind" ["ui", "workspace"],
+    "extensionKind": ["ui", "workspace"],
     "contributes": {
         "keybindings": [
             {


### PR DESCRIPTION
This should make it possible to use this extension in remote workspaces without having to also install the extension on the remote host.

Only tested by setting the "remote.extensionKind" override in local settings.
Fixes #16