### PR TITLE
Support alternate status bar modes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -24,7 +24,7 @@ function activate( context )
 
     function inactiveColour()
     {
-        return vscode.workspace.getConfiguration( 'activitusbar' ).get( 'inactiveColour' ) || new vscode.ThemeColor( 'statusBar.foreground' );
+        return vscode.workspace.getConfiguration( 'activitusbar' ).get( 'inactiveColour' );
     }
 
     function activeColour()


### PR DESCRIPTION
Some themes have white-on-dark status bar by default, but change it to black-on-bright for debug:

![Status bar in regular mode](https://user-images.githubusercontent.com/1298948/79277988-8abb5500-7eb3-11ea-9eaa-a04e6cfceae3.png)
![Status bar in debug more](https://user-images.githubusercontent.com/1298948/79278053-a32b6f80-7eb3-11ea-8c2f-46783b9ba778.png)

By removing the `statusBar.foreground` default for `inactiveColour` preference, we instead rely on the statusBar to set the colour for us, which adds support for debugging more and possible future modes as well:

![image](https://user-images.githubusercontent.com/1298948/79278175-e4238400-7eb3-11ea-9220-ae11c88a8f86.png)

