### PR TITLE
Add option to hide activitus bar, when atctivity bar showed

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
                     "type": "boolean",
                     "markownDescription": "Show a count of modified files next to the Source Control view button. *Note: Some users have reported that this interferes with VSCode dialogs.*",
                     "default": false
+                },
+                "activitusbar.toggleByActivityBar": {
+                    "type": "boolean",
+                    "description": "Hide activitus bar, when activity bar showed",
+                    "default": false
                 }
             }
         }


### PR DESCRIPTION
This solution continue to create buttons, but keep they have hidden, to minimize logic changes, and do not break hotkeys.
![activitusbar](https://github.com/Gruntfuggly/activitusbar/assets/12231048/917f236e-85a5-4af1-be42-9a608824ba05)
